### PR TITLE
MacOS installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Installation
 Run 'python ./setup.py install' from the props root directory.
 This will install several python packages and other resources which PropS uses and relies upon (see [requirements.txt](props/install/requirements.txt) and [install.sh](props/install/install.sh) for the complete list).
 
+MacOS users might run into issues installing JPype. An instruction to manually install JPype on MacOS can be found on the [berkely parser python interface repository](https://github.com/emcnany/berkeleyinterface#installation-and-dependencies).
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
The JPype installation fails on MacOS. I added a small paragraph with a pointer to the workaround.
